### PR TITLE
String guard changes we talked about 

### DIFF
--- a/src/ChaosMonkey.Guards.NetStandard.Tests/GuardTests.cs
+++ b/src/ChaosMonkey.Guards.NetStandard.Tests/GuardTests.cs
@@ -119,9 +119,9 @@ namespace ChaosMonkey.Guards.NetStandard.Tests
         {
             string argument = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(()=> Guard.IsNotNullOrWhitespace(argument, nameof(argument)));
+            var exception = Assert.Throws<ArgumentException>(()=> Guard.IsNotNullOrWhitespace(argument, nameof(argument)));
 
-            Assert.Equal("Value cannot be null.\r\nParameter name: argument", exception.Message);
+            Assert.Equal("Parameter 'argument' cannot be empty or whitespace only, but was '[NULL]'.\r\nParameter name: argument", exception.Message);
         }
 
         [Fact]
@@ -129,9 +129,9 @@ namespace ChaosMonkey.Guards.NetStandard.Tests
         {
             string argument = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(() => Guard.IsNotNullOrWhitespace(argument, null));
+            var exception = Assert.Throws<ArgumentException>(() => Guard.IsNotNullOrWhitespace(argument, null));
 
-            Assert.Equal("Value cannot be null.\r\nParameter name: [Unknown Argument Name]", exception.Message);
+            Assert.Equal("Parameter '[Unknown Argument Name]' cannot be empty or whitespace only, but was '[NULL]'.\r\nParameter name: [Unknown Argument Name]", exception.Message);
         }
 
         [Fact]

--- a/src/ChaosMonkey.Guards.NetStandard/Guard.cs
+++ b/src/ChaosMonkey.Guards.NetStandard/Guard.cs
@@ -80,11 +80,7 @@ namespace ChaosMonkey.Guards
             if (string.IsNullOrWhiteSpace(argument))
             {
                 var name = GetSafeArgumentName(argumentName);
-                if (argument == null)
-                {
-                    throw new ArgumentNullException(name);
-                }
-                var state = (argument.Length > 0) ? "[WHITESPACE-ONLY]" : "[EMPTY]";
+                var state = (argument == null) ? "[NULL]" : (argument.Length > 0) ? "[WHITESPACE-ONLY]" : "[EMPTY]";
                 throw new ArgumentException($"Parameter '{name}' cannot be empty or whitespace only, but was '{state}'.", name);
             }
             return argument;


### PR DESCRIPTION
So we can do:
`
[Theory]
[InlineData(" " )]
[InlineData("")]
[InlineData(null)]
public void Test_String(string s) 
{
       Assert.Throws<ArgumentNull>(()=> this.sut.DoSomethingWithS(s));
}
`

Making StringIsNotNullOrWhitespace only throw ArgumentException to co…mply with standard .Net conventions for this data type.